### PR TITLE
accessibility: add sr-only to footer icons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -158,6 +158,9 @@ footer {
     justify-content: space-between;
 }
 
+i {
+    color: #40342D;
+}
 
 /*---------- MEDIA QUERIES ----------*/
 /* Tablets */

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         <div class="audio__container">
             <a href="#" id="audioControl" class="btn">Play Music!</a>
             <audio id="yourAudio" preload='none'>
-                <source src='assets/sounds/theme.mp3' type='audio/mpeg' />
+                <source src='assets/sounds/theme.mp3' type='audio/mpeg'>
             </audio>
         </div>
     </nav>
@@ -61,7 +61,6 @@
     <!-- Site Banner -->
     <h1>THIS IS THE WAY</h1>
         <p>Help Grogu find his way back to the Madalorian!</p>
-    </div>
 
     <!-- Game Canvas -->
     <canvas id="game"></canvas>
@@ -76,55 +75,79 @@
             <ul>
                 <li>Kera Cudmore
                     <a href="https://github.com/kera-cudmore" target="_blank">
-                        <i class="fa-brands fa-square-github fa-lg"></i>
+                        <i class="fa-brands fa-square-github fa-lg" title="View Kera's GitHub Profile" aria-hidden="true">
+                          <span class="sr-only">View Kera's GitHub Profile</span>
+                        </i>
                     </a>
                     <a href="https://www.linkedin.com/in/keracudmore" target="_blank">
-                        <i class="fa-brands fa-linkedin fa-lg"></i>
+                        <i class="fa-brands fa-linkedin fa-lg" title="View Kera's LinkedIn Profile" aria-hidden="true">
+                          <span class="sr-only">View Kera's LinkedIn Profile</span>
+                        </i>
                     </a>
                 </li>
 
                 <li>Jody Murray
                     <a href="https://github.com/jodymurray" target="_blank">
-                        <i class="fa-brands fa-square-github fa-lg"></i>
+                        <i class="fa-brands fa-square-github fa-lg" title="View Jody's GitHub Profile" aria-hidden="true">
+                          <span class="sr-only">View Jody's GitHub Profile</span>
+                        </i>
                     </a>
                     <a href="https://www.linkedin.com/in/jodymurray" target="_blank">
-                        <i class="fa-brands fa-linkedin fa-lg"></i>
+                        <i class="fa-brands fa-linkedin fa-lg" title="View Jody's LinkedIn Profile" aria-hidden="true">
+                          <span class="sr-only">View Jody's LinkedIn Profile</span>
+                        </i>
                     </a>
                 </li>
 
                 <li>Tanguy Alexandre
                     <a href="https://github.com/tlalexandre" target="_blank">
-                        <i class="fa-brands fa-square-github fa-lg"></i>
+                        <i class="fa-brands fa-square-github fa-lg" title="View Tanguy's GitHub Profile" aria-hidden="true">
+                          <span class="sr-only">View Tanguy's GitHub Profile</span>
+                        </i>
                     </a>
                     <a href="https://www.linkedin.com/in/tanguy-l-alexandre-a72694272" target="_blank">
-                        <i class="fa-brands fa-linkedin fa-lg"></i>
+                        <i class="fa-brands fa-linkedin fa-lg" title="View Tanguy's LinkedIn Profile" aria-hidden="true">
+                          <span class="sr-only">View Tanguy's LinkedIn Profile</span>
+                        </i>
                     </a>
                 </li>
 
                 <li>Soorya George
                     <a href="https://github.com/SooryaGeorge7" target="_blank">
-                        <i class="fa-brands fa-square-github fa-lg"></i>
+                        <i class="fa-brands fa-square-github fa-lg" title="View Soorya's GitHub Profile" aria-hidden="true">
+                          <span class="sr-only">View Soorya's GitHub Profile</span>
+                        </i>
                     </a>
                     <a href="https://www.linkedin.com/in/soorya-george-6707a024a" target="_blank">
-                        <i class="fa-brands fa-linkedin fa-lg"></i>
+                        <i class="fa-brands fa-linkedin fa-lg" title="View Soorya's LinkedIn Profile" aria-hidden="true">
+                          <span class="sr-only">View Soorya's LinkedIn Profile</span>
+                        </i>
                     </a>
                 </li>
 
                 <li>Christian Göran
                     <a href="https://github.com/christiangoran" target="_blank">
-                        <i class="fa-brands fa-square-github fa-lg"></i>
+                        <i class="fa-brands fa-square-github fa-lg" title="View Christian's GitHub Profile" aria-hidden="true">
+                          <span class="sr-only">View Christian's GitHub Profile</span>
+                        </i>
                     </a>
                     <a href="https://www.linkedin.com/in/" target="_blank">
-                        <i class="fa-brands fa-linkedin fa-lg"></i>
+                        <i class="fa-brands fa-linkedin fa-lg" title="View Christian's LinkedIn Profile" aria-hidden="true">
+                          <span class="sr-only">View Christian's LinkedIn Profile</span>
+                        </i>
                     </a>
                 </li>
 
                 <li>Megan O'Donohoe
                     <a href="https://github.com/modonohoe" target="_blank">
-                        <i class="fa-brands fa-square-github fa-lg"></i>
+                        <i class="fa-brands fa-square-github fa-lg" title="View Megan's GitHub Profile" aria-hidden="true">
+                          <span class="sr-only">View Megan's GitHub Profile</span>
+                        </i>
                     </a>
                     <a href="https://www.linkedin.com/in/megan-o-donohoe-29022b264" target="_blank">
-                        <i class="fa-brands fa-linkedin fa-lg"></i>
+                        <i class="fa-brands fa-linkedin fa-lg" title="View Megan's LinkedIn Profile" aria-hidden="true">
+                          <span class="sr-only">View Megans's LinkedIn Profile</span>
+                        </i>
                     </a>
                 </li>
             </ul>


### PR DESCRIPTION
# This is the Way Pull Request
❗ _**Please replace the text below the headers with your own comments.**_ ❗️
![star-wars-g13b1929d3_640](https://github.com/kera-cudmore/JobTrackr/assets/92253071/5b1e17fc-3a0a-400f-83db-b09f547a8587)



## Pull Request details:

- made icons in footer more accessible by adding title and sr-only class for screen readers.
- removed trailing / in audio tag - flagged in HTML validation
- Coloured the icons in footer brown

## Any Breaking changes:

- none

## Associated Screenshots:

_( Feel free to add gifs/png screenshots of your feature in action 😊 )_

- none
